### PR TITLE
Fix retained audio cut short issue #3; added listen_key_padding_end_* settings

### DIFF
--- a/dragonfly/engines/backend_kaldi/engine.py
+++ b/dragonfly/engines/backend_kaldi/engine.py
@@ -484,13 +484,6 @@ class KaldiEngine(EngineBase, DelegateTimerManagerInterface):
                 nonlocal block
                 
                 # If we call early, e.g. release listen_key
-                if (block is not None) and (block is not False):
-                    self._log.log(14, "end_of_phrase called early")
-                    self._decoder.decode(block, False, None)
-                    if self.audio_store:
-                        self.audio_store.add_block(block)
-                    block = audio_iter.send(in_complex)
-                
                 listen_key_padding_end_ms_min = max(0, self._options['listen_key_padding_end_ms_min'])
                 listen_key_padding_end_ms_max = max(0, self._options['listen_key_padding_end_ms_max'])
                 listen_key_padding_end_always_max = self._options['listen_key_padding_end_always_max']
@@ -500,9 +493,11 @@ class KaldiEngine(EngineBase, DelegateTimerManagerInterface):
                 while ((current_time < padding_start_time_ns + (listen_key_padding_end_ms_max * (10**6)))
                        and (listen_key_padding_end_always_max 
                             or (current_time < padding_start_time_ns + (listen_key_padding_end_ms_min * (10**6))) 
-                            or ((block is not None) and (block is not False)))
+                            or (block is not None))
                        ):
                     self._log.log(14, "end_of_phrase called early")
+                    if block is False:
+                        time.sleep(0.001)
                     if (block is not None) and (block is not False):
                         self._decoder.decode(block, False, None)
                         if self.audio_store:

--- a/dragonfly/engines/backend_kaldi/engine.py
+++ b/dragonfly/engines/backend_kaldi/engine.py
@@ -474,6 +474,11 @@ class KaldiEngine(EngineBase, DelegateTimerManagerInterface):
                 nonlocal in_complex
                 nonlocal timed_out
                 nonlocal single
+                # If we call early, e.g. release listen_key
+                if block is not None and block is not False:
+                    self._decoder.decode(block, False, None)
+                    if self.audio_store:
+                        self.audio_store.add_block(block)
                 # End of phrase
                 self._decoder.decode(b'', True)
                 output, info = self._decoder.get_output()


### PR DESCRIPTION
Fix for issue #3 retained audio being cut short when using listen_key.
Adds settings for a "configurable time delay between `listen_key` release and ending the utterance `end_of_phrase()`"

Added settings:
- `listen_key_padding_end_ms_min` - before which, audio is collected (e.g. after releasing listen_key); after which, VAD can detect silence and end the utterance, or continue collecting up to `listen_key_padding_end_ms_max`.
- `listen_key_padding_end_ms_max` - after which no further audio is collected and utterance is ended.
- `listen_key_padding_end_always_max` - when set to True, always collects audio up to `listen_key_padding_end_ms_max`, ignores VAD.